### PR TITLE
SegTree/LazySegのマクロ名称変更

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,3 +67,8 @@ jobs:
           path: .verify-helper/cache/**/test
           key: testcases-cache-${{ matrix.testcase }}
           restore-keys: testcases-cache-${{ matrix.testcase }}
+  verify_check:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - run: echo "All tests passed!!"

--- a/datastructure/lazy-segment-tree.hpp
+++ b/datastructure/lazy-segment-tree.hpp
@@ -32,12 +32,15 @@ private:
   /// セグ木の遅延情報
   vec<F> _lazy;
 
+#ifndef SEG_MACROS
+#define SEG_MACROS
   /// 左の子のインデックスを返す
-#define L(i) (i << 1)
+#define SEG_L_CHILD(i) (i << 1)
   /// 右の子のインデックスを返す
-#define R(i) (i << 1 | 1)
+#define SEG_R_CHILD(i) (i << 1 | 1)
   /// 親のインデックスを返す
-#define P(i) (i >> 1)
+#define SEG_PARENT(i) (i >> 1)
+#endif
 
   /**
    * @brief k番目のノードの遅延情報を解消し、子ノードに伝搬する
@@ -49,8 +52,8 @@ private:
       return;
     _data[k] = apply(_lazy[k], _data[k]);
     if (k < _n) {
-      _lazy[L(k)] = merge(_lazy[L(k)], _lazy[k]);
-      _lazy[R(k)] = merge(_lazy[R(k)], _lazy[k]);
+      _lazy[SEG_L_CHILD(k)] = merge(_lazy[SEG_L_CHILD(k)], _lazy[k]);
+      _lazy[SEG_R_CHILD(k)] = merge(_lazy[SEG_R_CHILD(k)], _lazy[k]);
     }
     _lazy[k] = id;
   }
@@ -75,8 +78,8 @@ public:
                                   const function<T(T, T)> op,
                                   const function<T(F, T)> apply,
                                   const function<F(F, F)> merge)
-      : e(e), id(id), op(op), apply(apply), merge(merge), _n(bit_ceil(length)),
-        _height(bit_width(_n) - 1), _data(2 * _n, e), _lazy(2 * _n, id) {}
+    : e(e), id(id), op(op), apply(apply), merge(merge), _n(bit_ceil(length)),
+    _height(bit_width(_n) - 1), _data(2 * _n, e), _lazy(2 * _n, id) {}
 
   /**
    * @brief 既存のベクトルからLazySegmentTreeを生成する
@@ -92,12 +95,12 @@ public:
                                   const function<T(T, T)> op,
                                   const function<T(F, T)> apply,
                                   const function<F(F, F)> merge)
-      : e(e), id(id), op(op), apply(apply), merge(merge),
-        _n(bit_ceil(data.size())), _height(bit_width(_n) - 1), _data(2 * _n, e),
-        _lazy(2 * _n, id) {
+    : e(e), id(id), op(op), apply(apply), merge(merge),
+    _n(bit_ceil(data.size())), _height(bit_width(_n) - 1), _data(2 * _n, e),
+    _lazy(2 * _n, id) {
     rep(i, data.size()) _data[i + _n] = data[i];
     for (int i = _n - 1; i > 0; --i)
-      _data[i] = op(_data[L(i)], _data[R(i)]);
+      _data[i] = op(_data[SEG_L_CHILD(i)], _data[SEG_R_CHILD(i)]);
   }
 
   /**

--- a/datastructure/segment-tree.hpp
+++ b/datastructure/segment-tree.hpp
@@ -17,12 +17,15 @@ private:
   /// SegTreeのノード上のデータ
   vec<T> data;
 
-/// 左の子のインデックスを返す
-#define L(i) (i << 1)
-/// 右の子のインデックスを返す
-#define R(i) (i << 1 | 1)
-/// 親のインデックスを返す
-#define P(i) (i >> 1)
+#ifndef SEG_MACROS
+#define SEG_MACROS
+  /// 左の子のインデックスを返す
+#define SEG_L_CHILD(i) (i << 1)
+  /// 右の子のインデックスを返す
+#define SEG_R_CHILD(i) (i << 1 | 1)
+  /// 親のインデックスを返す
+#define SEG_PARENT(i) (i >> 1)
+#endif
 
 public:
   /**
@@ -33,7 +36,7 @@ public:
    * @param op 演算
    */
   explicit SegmentTree(int length, T e, function<T(T, T)> op)
-      : e(e), op(op), n(bit_ceil(length)), data(2 * n, e) {}
+  : e(e), op(op), n(bit_ceil(length)), data(2 * n, e) {}
 
   /**
    * @brief 既存のベクトルからSegmentTreeを生成する
@@ -43,10 +46,10 @@ public:
    * @param op 演算
    */
   explicit SegmentTree(const vec<T> &v, T e, function<T(T, T)> op)
-      : e(e), op(op), n(bit_ceil(v.size())), data(2 * n, e) {
+    : e(e), op(op), n(bit_ceil(v.size())), data(2 * n, e) {
     rep(i, v.size()) data[i + n] = v[i];
     for (int i = n - 1; i > 0; --i)
-      data[i] = op(data[L(i)], data[R(i)]);
+      data[i] = op(data[SEG_L_CHILD(i)], data[SEG_R_CHILD(i)]);
   }
 
   /**
@@ -58,8 +61,8 @@ public:
   void set(int i, T a) {
     i += n;
     data[i] = a;
-    while (i = P(i), i > 0)
-      data[i] = op(data[L(i)], data[R(i)]);
+    while (i = SEG_PARENT(i), i > 0)
+      data[i] = op(data[SEG_L_CHILD(i)], data[SEG_R_CHILD(i)]);
   }
 
   /**
@@ -85,7 +88,7 @@ public:
         l_val = op(l_val, data[l++]);
       if (r & 1)
         r_val = op(data[--r], r_val);
-      l = P(l), r = P(r);
+      l = SEG_PARENT(l), r = SEG_PARENT(r);
     }
     return op(l_val, r_val);
   }


### PR DESCRIPTION
マクロはスコープを貫通して動作するため、`L`、`R`、`P`といった変数名が使えなくなっていたため